### PR TITLE
Bugfix: Overwritten Results

### DIFF
--- a/BenchmarkIt/Result.cs
+++ b/BenchmarkIt/Result.cs
@@ -232,7 +232,7 @@ namespace BenchmarkIt
                 {
                     Console.Write(outputColumns[c].ToString().PadRight(_iterationResultColumns[c].Width));
                 }
-                Console.Write("\n");
+                Console.WriteLine("");
             }
             Console.ForegroundColor = originalColor;
         }


### PR DESCRIPTION
Results were overwritten when using Benchmark.This().Against.This() (like in the Readme-Sample), since the before used Console.Write("\n") didn't result in an actual new line and the afterwards written output replaced the previously written one.